### PR TITLE
[Feature] Token process

### DIFF
--- a/Targets/MorningBear/Sources/Login/LoginViewController.swift
+++ b/Targets/MorningBear/Sources/Login/LoginViewController.swift
@@ -49,6 +49,7 @@ class LoginViewController: UIViewController {
         }
     }
     
+    
     private let kakaoLoginManager: KakaoLoginManager = KakaoLoginManager()
     private let appleLoginManager: AppleLoginManager = AppleLoginManager()
     private let bag = DisposeBag()
@@ -71,8 +72,15 @@ class LoginViewController: UIViewController {
         
         appleLoginButton.rx.tap.bind { [weak self] _ in
             guard let self = self else { return }
-            self.appleLoginManager.login()
+            
+            self.appleLoginManager.login(presentWindow: self)
         }
         .disposed(by: bag)
+    }
+}
+
+extension LoginViewController: ASAuthorizationControllerPresentationContextProviding {
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        return self.view.window!
     }
 }

--- a/Targets/MorningBearKit/Sources/Auth/AppleLoginManager.swift
+++ b/Targets/MorningBearKit/Sources/Auth/AppleLoginManager.swift
@@ -22,7 +22,7 @@ public final class AppleLoginManager: NSObject {
     }
     
     public func checkCredentialState() {
-        guard let userIdentifier = UserDefaultsManager.shared.userIdentifier else { return }
+        guard let userIdentifier = AuthUserDefaultsManager.shared.userIdentifier else { return }
         
         let appleIDProvider = ASAuthorizationAppleIDProvider()
         appleIDProvider.getCredentialState(forUserID: userIdentifier) { credentialState, error in
@@ -54,7 +54,7 @@ extension AppleLoginManager: ASAuthorizationControllerDelegate {
             guard let idToken = String(data: appleIDCredential.identityToken!, encoding: .utf8) else { return }
             
             print("User id is \(userIdentifier) \n Email is \(String(describing: email)) \n ID token is \(idToken)")
-            tokenManager.saveUserIdentifierAtLocal(userIdentifier)
+            tokenManager.saveAppleUserIdentifierAtLocal(userIdentifier)
             tokenManager.progressApple(token: idToken)
         }
     }

--- a/Targets/MorningBearKit/Sources/Auth/AppleLoginManager.swift
+++ b/Targets/MorningBearKit/Sources/Auth/AppleLoginManager.swift
@@ -23,7 +23,7 @@ public final class AppleLoginManager: NSObject {
     }
     
     public func checkCredentialState() {
-        guard let userIdentifier = UserDefaultsManager.shared.userIdentifier else { return }
+        guard let userIdentifier = AuthUserDefaultsManager.shared.userIdentifier else { return }
         
         let appleIDProvider = ASAuthorizationAppleIDProvider()
         appleIDProvider.getCredentialState(forUserID: userIdentifier) { credentialState, error in
@@ -61,7 +61,7 @@ extension AppleLoginManager: ASAuthorizationControllerDelegate {
             guard let idToken = String(data: appleIDCredential.identityToken!, encoding: .utf8) else { return }
             
             print("User id is \(userIdentifier) \n Email is \(String(describing: email)) \n ID token is \(idToken)")
-            tokenManager.saveUserIdentifierAtLocal(userIdentifier)
+            tokenManager.saveAppleUserIdentifierAtLocal(userIdentifier)
             tokenManager.progressApple(token: idToken)
         }
     }

--- a/Targets/MorningBearKit/Sources/Auth/AppleLoginManager.swift
+++ b/Targets/MorningBearKit/Sources/Auth/AppleLoginManager.swift
@@ -9,16 +9,15 @@
 import AuthenticationServices
 
 public final class AppleLoginManager: NSObject {
-    
-    public weak var viewController: UIViewController?
     private let tokenManager: TokenManager
     
-    public func login() {
+    public func login(presentWindow presentationContextProvider: ASAuthorizationControllerPresentationContextProviding) {
         let request = ASAuthorizationAppleIDProvider().createRequest()
         request.requestedScopes = [.email]
+        
         let controller = ASAuthorizationController(authorizationRequests: [request])
         controller.delegate = self
-        controller.presentationContextProvider = self
+        controller.presentationContextProvider = presentationContextProvider
         controller.performRequests()
     }
     
@@ -44,12 +43,6 @@ public final class AppleLoginManager: NSObject {
     
     public override init() {
         self.tokenManager = TokenManager()
-    }
-}
-
-extension AppleLoginManager: ASAuthorizationControllerPresentationContextProviding {
-    public func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
-        return viewController!.view.window!
     }
 }
 

--- a/Targets/MorningBearKit/Sources/Auth/AuthUserDefaultsManager.swift
+++ b/Targets/MorningBearKit/Sources/Auth/AuthUserDefaultsManager.swift
@@ -1,5 +1,5 @@
 //
-//  UserDefaultsManager.swift
+//  AuthUserDefaultsManager.swift
 //  MorningBearUITests
 //
 //  Created by 이건우 on 2023/01/07.
@@ -8,9 +8,9 @@
 
 import Foundation
 
-public class UserDefaultsManager {
+public class AuthUserDefaultsManager {
     
-    public static let shared: UserDefaultsManager = UserDefaultsManager()
+    public static let shared: AuthUserDefaultsManager = AuthUserDefaultsManager()
     private let defaults = UserDefaults.standard
     
     /// key값을 enum으로 래핑해서 사용, 필요한 key값이 늘어나면 따로 추가할 예정

--- a/Targets/MorningBearKit/Sources/Auth/KakaoLoginManager.swift
+++ b/Targets/MorningBearKit/Sources/Auth/KakaoLoginManager.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 com.dache. All rights reserved.
 //
 
+import Foundation
 import RxKakaoSDKUser
 import KakaoSDKUser
 import RxKakaoSDKAuth
@@ -28,10 +29,9 @@ public final class KakaoLoginManager {
                     guard let self = self else { return }
                     
                     print("loginWithKakaoTalk() success.")
-                    let accessToken = oauthToken.accessToken
-                    self.tokenManager.encodeToken(state: .kakao, token: accessToken)
+                    self.tokenManager.progressKakao(oauthToken: oauthToken)
                     
-                }, onError: {error in
+                }, onError: { error in
                     print(error)
                 })
                 .disposed(by: bag)
@@ -44,10 +44,9 @@ public final class KakaoLoginManager {
                     guard let self = self else { return }
                     
                     print("loginWithKakaoAccount() success.")
-                    let accessToken = oauthToken.accessToken
-                    self.tokenManager.encodeToken(state: .kakao, token: accessToken)
+                    self.tokenManager.progressKakao(oauthToken: oauthToken)
                     
-                }, onError: {error in
+                }, onError: { error in
                     print(error)
                 })
                 .disposed(by: bag)
@@ -61,41 +60,18 @@ public final class KakaoLoginManager {
                 
                 //do something
                 _ = user
-            }, onFailure: {error in
+            }, onFailure: { error in
                 print(error)
             })
             .disposed(by: bag)
     }
     
-    public func verifyToken() {
-        // !! has error need to fix
-        
-        /*
-        if (AuthApi.hasToken()) {
-            UserApi.shared.rx.accessTokenInfo()
-                .subscribe(onSuccess:{ (_) in
-                    // 토큰 유효성 체크 성공 (필요 시 토큰 갱신됨)
-                }, onFailure: {error in
-                    if let sdkError = error as? SdkError, sdkError.isInvalidTokenError() == true {
-                        // 로그인 필요
-                    }
-                    else {
-                        // 기타 에러
-                    }
-                })
-                .disposed(by: disposeBag)
-        }
-        
-        else {
-         
-            // 로그인 필요
-        }
-        */
-    }
-    
     public func logout() {
         UserApi.shared.rx.logout()
-            .subscribe(onCompleted:{
+            .subscribe(onCompleted: { [weak self] in
+                guard let self = self else { return }
+                self.tokenManager.removeMorningBearTokenAtLocal()
+                
                 print("logout() success.")
             }, onError: {error in
                 print(error)
@@ -105,9 +81,12 @@ public final class KakaoLoginManager {
     
     public func deleteUser() {
         UserApi.shared.rx.unlink()
-            .subscribe(onCompleted:{
+            .subscribe(onCompleted: { [weak self] in
+                guard let self = self else { return }
+                self.tokenManager.removeMorningBearTokenAtLocal()
+                
                 print("unlink() success.")
-            }, onError: {error in
+            }, onError: { error in
                 print(error)
             })
             .disposed(by: bag)

--- a/Targets/MorningBearKit/Sources/Auth/KakaoLoginManager.swift
+++ b/Targets/MorningBearKit/Sources/Auth/KakaoLoginManager.swift
@@ -70,7 +70,7 @@ public final class KakaoLoginManager {
         UserApi.shared.rx.logout()
             .subscribe(onCompleted: { [weak self] in
                 guard let self = self else { return }
-                self.tokenManager.removeMorningBearTokenAtLocal()
+                self.tokenManager.removeAll()
                 
                 print("logout() success.")
             }, onError: {error in
@@ -83,7 +83,7 @@ public final class KakaoLoginManager {
         UserApi.shared.rx.unlink()
             .subscribe(onCompleted: { [weak self] in
                 guard let self = self else { return }
-                self.tokenManager.removeMorningBearTokenAtLocal()
+                self.tokenManager.removeAll()
                 
                 print("unlink() success.")
             }, onError: { error in

--- a/Targets/MorningBearKit/Sources/Auth/KakaoLoginManager.swift
+++ b/Targets/MorningBearKit/Sources/Auth/KakaoLoginManager.swift
@@ -70,7 +70,7 @@ public final class KakaoLoginManager {
         UserApi.shared.rx.logout()
             .subscribe(onCompleted: { [weak self] in
                 guard let self = self else { return }
-                self.tokenManager.removeAll()
+                self.tokenManager.removeAllAuthorizationData()
                 
                 print("logout() success.")
             }, onError: {error in
@@ -83,7 +83,7 @@ public final class KakaoLoginManager {
         UserApi.shared.rx.unlink()
             .subscribe(onCompleted: { [weak self] in
                 guard let self = self else { return }
-                self.tokenManager.removeAll()
+                self.tokenManager.removeAllAuthorizationData()
                 
                 print("unlink() success.")
             }, onError: { error in

--- a/Targets/MorningBearKit/Sources/Auth/TokenManager.swift
+++ b/Targets/MorningBearKit/Sources/Auth/TokenManager.swift
@@ -6,30 +6,117 @@
 //  Copyright © 2023 com.dache. All rights reserved.
 //
 
+import Foundation
+
 import MorningBearNetwork
 import MorningBearAPI
+import KakaoSDKAuth
 
 public final class TokenManager {
     
     public enum AuthState: String {
-        case kakao = "kakao"
-        case apple = "apple"
+        case kakao
+        case apple
     }
     
-    public func encodeToken(state: AuthState, token: String) {
+    public var hasMorningBearToken: Bool {
+        return UserDefaultsManager.shared.morningBearToken != nil
+    }
+    
+    /// Apple 로그인 후 엑세스 토큰에 필요한 프로세스를 진행합니다
+    ///
+    /// Apple 엑세스 토큰을 앱에서 사용되는 토큰으로 인코딩 후, UserDefault에 저장
+    public func progressApple(token: String) {
         Network.shared.apollo
-            .fetch(query: EncodeQuery(state: GraphQLNullable(stringLiteral: state.rawValue), token: GraphQLNullable(stringLiteral: token))) { result in
+            .fetch(query: EncodeQuery(state: GraphQLNullable(stringLiteral: AuthState.apple.rawValue), token: GraphQLNullable(stringLiteral: token))) { result in
             switch result {
             case .success(let graphQLResult):
                 guard let encodedToken = graphQLResult.data?.encode else { return }
                 
-                // FIXME: RxApollo 적용 후 encodedToken을 LocalStorageManager를 통해 저장
-                // 혹은 리턴 후 Apple/Kakao 로그인 매니저에서 따로 처리
                 print("encodedToken is", encodedToken)
+                self.saveAuthStateAtLocal(.apple)
+                self.saveMorningBearTokenAtLocal(encodedToken)
                 
             case .failure(let error):
                 print(error)
             }
         }
+    }
+    
+    /// Kakao 로그인 후 엑세스 토큰에 필요한 프로세스를 진행합니다
+    ///
+    /// Kakao 엑세스 토큰을 앱에서 사용되는 토큰으로 인코딩 후, UserDefault에 저장.  만료일과 리프레시 토큰 또한 UserDefault에 별도로 저장
+    public func progressKakao(oauthToken: OAuthToken) {
+        Network.shared.apollo
+            .fetch(query: EncodeQuery(state: GraphQLNullable(stringLiteral: AuthState.kakao.rawValue), token: GraphQLNullable(stringLiteral: oauthToken.accessToken))) { result in
+            switch result {
+            case .success(let graphQLResult):
+                guard let encodedToken = graphQLResult.data?.encode else { return }
+                
+                print("encodedToken is", encodedToken)
+                self.saveAuthStateAtLocal(.kakao)
+                self.saveMorningBearTokenAtLocal(encodedToken)
+                self.saveRefreshTokenAtLocal(oauthToken.refreshToken)
+                self.saveExpirationDateAtLocal(oauthToken.expiredAt)
+                
+            case .failure(let error):
+                print(error)
+            }
+        }
+    }
+    
+    /// 로그인 시 사용한 서비스를 로컬에 저장 (apple, kakao)
+    private func saveAuthStateAtLocal(_ state: AuthState) {
+        UserDefaultsManager.shared.authState = state.rawValue
+    }
+    
+    /// MorningBear token을 로컬에 저장
+    private func saveMorningBearTokenAtLocal(_ token: String) {
+        UserDefaultsManager.shared.morningBearToken = token
+    }
+    
+    /// MorningBear token을 로컬에서 삭제
+    func removeMorningBearTokenAtLocal() {
+        UserDefaultsManager.shared.morningBearToken = nil
+    }
+    
+    /// 로그아웃 혹은 회원탈퇴시 인증과 관련된 모든 토큰 및 데이터를 로컬에서 삭제
+    func removeAll() {
+        removeMorningBearTokenAtLocal()
+        removeUserIdentifierAtLocal()
+        removeRefreshTokenAtLocal()
+        removeExpirationDateAtLocal()
+    }
+    
+    // MARK: - Only for Apple
+    /// UserDefaultManager를 통해 kakao refresh token 저장
+    func saveUserIdentifierAtLocal(_ uid: String) {
+        UserDefaultsManager.shared.userIdentifier = uid
+    }
+    
+    /// UserDefaultManager를 통해 kakao refresh token 저장
+    func removeUserIdentifierAtLocal() {
+        UserDefaultsManager.shared.userIdentifier = nil
+    }
+    
+    // MARK: - Only For Kakao
+    /// UserDefaultManager를 통해 kakao refresh token 저장
+    private func saveRefreshTokenAtLocal(_ token: String) {
+        UserDefaultsManager.shared.refreshToken = token
+    }
+    
+    /// UserDefaultManager를 통해 kakao refresh token 저장
+    func removeRefreshTokenAtLocal() {
+        UserDefaultsManager.shared.refreshToken = nil
+    }
+    
+    /// UserDefaultManager를 통해 kakao access token 만료일 저장
+    private func saveExpirationDateAtLocal(_ date: Date) {
+        UserDefaultsManager.shared.expirationDate = date
+    }
+    
+    /// UserDefaultManager를 통해 kakao access token 만료일 삭제
+    func removeExpirationDateAtLocal() {
+        UserDefaultsManager.shared.expirationDate = nil
     }
 }

--- a/Targets/MorningBearKit/Sources/Auth/TokenManager.swift
+++ b/Targets/MorningBearKit/Sources/Auth/TokenManager.swift
@@ -86,7 +86,7 @@ public final class TokenManager {
     }
     
     /// 로그아웃 혹은 회원탈퇴시 인증과 관련된 모든 토큰 및 데이터를 로컬에서 삭제
-    func removeAll() {
+    func removeAllAuthorizationData() {
         removeAuthStateAtLocal()
         removeMorningBearTokenAtLocal()
         removeAppleUserIdentifierAtLocal()

--- a/Targets/MorningBearKit/Sources/Auth/TokenManager.swift
+++ b/Targets/MorningBearKit/Sources/Auth/TokenManager.swift
@@ -65,9 +65,14 @@ public final class TokenManager {
         }
     }
     
-    /// 로그인 시 사용한 서비스를 로컬에 저장 (apple, kakao)
+    /// 로그인 시 사용한 서비스명을 로컬에 저장 (apple, kakao)
     private func saveAuthStateAtLocal(_ state: AuthState) {
         UserDefaultsManager.shared.authState = state.rawValue
+    }
+    
+    /// 로그인 시 사용한 서비스명을 로컬에서 삭제 (apple, kakao)
+    private func removeAuthStateAtLocal() {
+        UserDefaultsManager.shared.authState = nil
     }
     
     /// MorningBear token을 로컬에 저장
@@ -82,6 +87,7 @@ public final class TokenManager {
     
     /// 로그아웃 혹은 회원탈퇴시 인증과 관련된 모든 토큰 및 데이터를 로컬에서 삭제
     func removeAll() {
+        removeAuthStateAtLocal()
         removeMorningBearTokenAtLocal()
         removeUserIdentifierAtLocal()
         removeRefreshTokenAtLocal()

--- a/Targets/MorningBearKit/Sources/Auth/TokenManager.swift
+++ b/Targets/MorningBearKit/Sources/Auth/TokenManager.swift
@@ -95,12 +95,12 @@ public final class TokenManager {
     }
     
     // MARK: - Only for Apple
-    /// UserDefaultManager를 통해 kakao refresh token 저장
+    /// UserDefaultManager를 통해 apple의 userIdentifier 값을 로컬에 저장
     func saveUserIdentifierAtLocal(_ uid: String) {
         UserDefaultsManager.shared.userIdentifier = uid
     }
     
-    /// UserDefaultManager를 통해 kakao refresh token 저장
+    /// UserDefaultManager를 통해 apple의 userIdentifier 값을 로컬에서 삭제
     func removeUserIdentifierAtLocal() {
         UserDefaultsManager.shared.userIdentifier = nil
     }

--- a/Targets/MorningBearKit/Sources/Auth/TokenManager.swift
+++ b/Targets/MorningBearKit/Sources/Auth/TokenManager.swift
@@ -20,7 +20,7 @@ public final class TokenManager {
     }
     
     public var hasMorningBearToken: Bool {
-        return UserDefaultsManager.shared.morningBearToken != nil
+        return AuthUserDefaultsManager.shared.morningBearToken != nil
     }
     
     /// Apple 로그인 후 엑세스 토큰에 필요한 프로세스를 진행합니다
@@ -56,8 +56,8 @@ public final class TokenManager {
                 print("encodedToken is", encodedToken)
                 self.saveAuthStateAtLocal(.kakao)
                 self.saveMorningBearTokenAtLocal(encodedToken)
-                self.saveRefreshTokenAtLocal(oauthToken.refreshToken)
-                self.saveExpirationDateAtLocal(oauthToken.expiredAt)
+                self.saveKakaoRefreshTokenAtLocal(oauthToken.refreshToken)
+                self.saveKakaoExpirationDateAtLocal(oauthToken.expiredAt)
                 
             case .failure(let error):
                 print(error)
@@ -67,62 +67,62 @@ public final class TokenManager {
     
     /// 로그인 시 사용한 서비스명을 로컬에 저장 (apple, kakao)
     private func saveAuthStateAtLocal(_ state: AuthState) {
-        UserDefaultsManager.shared.authState = state.rawValue
+        AuthUserDefaultsManager.shared.authState = state.rawValue
     }
     
     /// 로그인 시 사용한 서비스명을 로컬에서 삭제 (apple, kakao)
     private func removeAuthStateAtLocal() {
-        UserDefaultsManager.shared.authState = nil
+        AuthUserDefaultsManager.shared.authState = nil
     }
     
     /// MorningBear token을 로컬에 저장
     private func saveMorningBearTokenAtLocal(_ token: String) {
-        UserDefaultsManager.shared.morningBearToken = token
+        AuthUserDefaultsManager.shared.morningBearToken = token
     }
     
     /// MorningBear token을 로컬에서 삭제
     func removeMorningBearTokenAtLocal() {
-        UserDefaultsManager.shared.morningBearToken = nil
+        AuthUserDefaultsManager.shared.morningBearToken = nil
     }
     
     /// 로그아웃 혹은 회원탈퇴시 인증과 관련된 모든 토큰 및 데이터를 로컬에서 삭제
     func removeAll() {
         removeAuthStateAtLocal()
         removeMorningBearTokenAtLocal()
-        removeUserIdentifierAtLocal()
-        removeRefreshTokenAtLocal()
-        removeExpirationDateAtLocal()
+        removeAppleUserIdentifierAtLocal()
+        removeKakaoRefreshTokenAtLocal()
+        removeKakaoExpirationDateAtLocal()
     }
     
     // MARK: - Only for Apple
     /// UserDefaultManager를 통해 apple의 userIdentifier 값을 로컬에 저장
-    func saveUserIdentifierAtLocal(_ uid: String) {
-        UserDefaultsManager.shared.userIdentifier = uid
+    func saveAppleUserIdentifierAtLocal(_ uid: String) {
+        AuthUserDefaultsManager.shared.userIdentifier = uid
     }
     
     /// UserDefaultManager를 통해 apple의 userIdentifier 값을 로컬에서 삭제
-    func removeUserIdentifierAtLocal() {
-        UserDefaultsManager.shared.userIdentifier = nil
+    func removeAppleUserIdentifierAtLocal() {
+        AuthUserDefaultsManager.shared.userIdentifier = nil
     }
     
     // MARK: - Only For Kakao
     /// UserDefaultManager를 통해 kakao refresh token 저장
-    private func saveRefreshTokenAtLocal(_ token: String) {
-        UserDefaultsManager.shared.refreshToken = token
+    private func saveKakaoRefreshTokenAtLocal(_ token: String) {
+        AuthUserDefaultsManager.shared.refreshToken = token
     }
     
-    /// UserDefaultManager를 통해 kakao refresh token 저장
-    func removeRefreshTokenAtLocal() {
-        UserDefaultsManager.shared.refreshToken = nil
+    /// UserDefaultManager를 통해 kakao refresh token 삭제
+    func removeKakaoRefreshTokenAtLocal() {
+        AuthUserDefaultsManager.shared.refreshToken = nil
     }
     
     /// UserDefaultManager를 통해 kakao access token 만료일 저장
-    private func saveExpirationDateAtLocal(_ date: Date) {
-        UserDefaultsManager.shared.expirationDate = date
+    private func saveKakaoExpirationDateAtLocal(_ date: Date) {
+        AuthUserDefaultsManager.shared.expirationDate = date
     }
     
     /// UserDefaultManager를 통해 kakao access token 만료일 삭제
-    func removeExpirationDateAtLocal() {
-        UserDefaultsManager.shared.expirationDate = nil
+    func removeKakaoExpirationDateAtLocal() {
+        AuthUserDefaultsManager.shared.expirationDate = nil
     }
 }

--- a/Targets/MorningBearKit/Sources/UserDefaults/UserDefaultsManager.swift
+++ b/Targets/MorningBearKit/Sources/UserDefaults/UserDefaultsManager.swift
@@ -1,0 +1,56 @@
+//
+//  UserDefaultsManager.swift
+//  MorningBearUITests
+//
+//  Created by 이건우 on 2023/01/07.
+//  Copyright © 2023 com.dache. All rights reserved.
+//
+
+import Foundation
+
+public class UserDefaultsManager {
+    
+    public static let shared: UserDefaultsManager = UserDefaultsManager()
+    private let defaults = UserDefaults.standard
+    
+    /// key값을 enum으로 래핑해서 사용, 필요한 key값이 늘어나면 따로 추가할 예정
+    private enum UserDefaultsKey: String {
+        case authState
+        case morningBearToken
+        case refreshToken
+        case expirationDate
+        case userIdentifier
+    }
+    
+    /// 현재 로그인 되어있는 서비스를 의미합니다. apple or kakao
+    var authState: String? {
+        set { defaults.setValue(newValue, forKey: UserDefaultsKey.authState.rawValue) }
+        get { defaults.string(forKey: UserDefaultsKey.authState.rawValue) }
+    }
+    
+    /// MorningBear앱 내에서 사용되는 식별 토큰입니다
+    var morningBearToken: String? {
+        set { defaults.setValue(newValue, forKey: UserDefaultsKey.morningBearToken.rawValue) }
+        get { defaults.string(forKey: UserDefaultsKey.morningBearToken.rawValue) }
+    }
+    
+    /// apple을 통해 로그인 했을 시 로그인 상태를 체크할 때 필요한 값 입니다
+    var userIdentifier: String? {
+        set { defaults.setValue(newValue, forKey: UserDefaultsKey.userIdentifier.rawValue) }
+        get { defaults.string(forKey: UserDefaultsKey.userIdentifier.rawValue) }
+    }
+    
+    /// kakao를 통해 로그인 했을 시 필요한 refresh token입니다
+    var refreshToken: String? {
+        set { defaults.setValue(newValue, forKey: UserDefaultsKey.refreshToken.rawValue) }
+        get { defaults.string(forKey: UserDefaultsKey.refreshToken.rawValue) }
+    }
+    
+    /// kakao access token이 만료되는 시각입니다.
+    var expirationDate: Date? {
+        set { defaults.setValue(newValue, forKey: UserDefaultsKey.expirationDate.rawValue) }
+        get { defaults.object(forKey: UserDefaultsKey.expirationDate.rawValue) as? Date }
+    }
+    
+    private init() {}
+}


### PR DESCRIPTION
## What is this PR? 👀
apple, kakao 로그인 후 각 서비스별 토큰을 앱에서 잘 사용할 수 있도록 처리합니다.
<br><br/>

## Changes 📃
UserDefaultsManager 생성 및 각 서비스별 토큰 프로세싱 기능 개발
<br><br/>

## Screenshot (optional) 📷
스크린샷이 있다면 첨부해주세요.
<br><br/>

## Additional & Warning points (optional) 📌
앱 사용중에 사용자가 설정에서 Apple id 연결을 중단했을 시 앱이 아무것도 못하게 되는 상황을 방지하기 위해 didFinishLaunchingWithOptions 와 applicationDidBecomeActive 두 군데서ASAuthorizationAppleIDProvider()를 통하여 체크할 예정입니다. (AppDelegate 또는 SceneDelegate가 UserDefaultManager.shared를 사용함)

또한 현재 코드는 UserDefaults 값을 활용해 앱 진입시 **로그인 상태, 토큰만료 여부**와 같은 분기처리를 할 수 있도록 설계되어 있습니다. 하지만 이 흐름이 좋은 흐름인지 잘 모르겠습니다. (AppDelegate 또는 SceneDelegate가 UserDefaultManager.shared를 사용하는 흐름)
<br><br/>

## Test result 🧪
직접 실행해서 테스트.
테스트코드 작성해볼 예정 ex) 카카오로 로그인 시 refreshToken, expirationDate와 같은 userDefauts 데이터가 nil이 아닌지
